### PR TITLE
Add support to generate query string params

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed'],
     'indent': ['error', 2],
     'class-methods-use-this': ['error', { 'exceptMethods': ['boot'] }],
+    'max-len': ['error', { 'code': 120 }],
     'no-useless-constructor': 0,
     'no-param-reassign': 0,
     'no-console': 0,
@@ -23,6 +24,7 @@ module.exports = {
   },
   'globals': {
     'it': true,
+    'xit': true,
     'describe': true,
     'beforeAll': true,
     'beforeEach': true,

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,14 +23,28 @@ exports.default = function () {
     return [];
   };
 
-  var _replaceURLParams = function _replaceURLParams(url, urlParams) {
+  var _stringifyParams = function _stringifyParams(params) {
+    return Object.keys(params).reduce(function (acc, k) {
+      return '' + acc + k + '=' + encodeURIComponent(params[k]) + '&';
+    }, '').replace(/&$/, '');
+  };
+
+  var _replaceURLParams = function _replaceURLParams(url, urlParams, queryParams) {
     var routeParams = _getUrlParams(url);
     var mappedUrl = url;
 
-    if (routeParams.length && Object.keys(urlParams).length !== 0) {
-      routeParams.forEach(function (param) {
-        mappedUrl = mappedUrl.replace('{' + param + '}', urlParams[param]);
-      });
+    if (Object.keys(urlParams).length !== 0) {
+      if (routeParams.length) {
+        routeParams.forEach(function (param) {
+          mappedUrl = mappedUrl.replace('{' + param + '}', urlParams[param]);
+        });
+      } else {
+        mappedUrl = mappedUrl + '?' + _stringifyParams(urlParams);
+      }
+    }
+
+    if (Object.keys(queryParams).length !== 0) {
+      mappedUrl = mappedUrl + '?' + _stringifyParams(queryParams);
     }
 
     return mappedUrl;
@@ -42,7 +56,8 @@ exports.default = function () {
 
   var generate = function generate(k) {
     var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    return _replaceURLParams(_get(k), params);
+    var queryParams = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    return _replaceURLParams(_get(k), params, queryParams);
   };
 
   var set = function set(k, v) {
@@ -87,6 +102,7 @@ exports.default = function () {
 
     _get: _get,
     _getUrlParams: _getUrlParams,
-    _replaceURLParams: _replaceURLParams
+    _replaceURLParams: _replaceURLParams,
+    _stringifyParams: _stringifyParams
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "routegen",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "routegen",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "compile": "babel --presets=es2015 --no-comments -d dist src",
     "lint": "eslint --ext .js src test",
     "lint:fix": "npm run lint -- --fix",
-    "unit": "jest --maxWorkers 2",
+    "unit": "jest test --maxWorkers 2",
     "unit:watch": "jest test --watch",
     "prepare": "npm run compile"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,6 @@ export default (config = {}) => {
   const _stringifyParams = params => Object.keys(params)
     .reduce((acc, k) => `${acc}${k}=${encodeURIComponent(params[k])}&`, '')
     .replace(/&$/, '');
-  //   const queryString = [];
-
-  //   Object.keys(params).forEach(k => {
-  //     queryString.push(`${k}=${encodeURIComponent(params[k])}`);
-  //   });
-
-  //   return queryString.join('&');
-  // };
 
   /**
    * This replaces any interpolated params with items passed in via the routeParams object

--- a/src/index.js
+++ b/src/index.js
@@ -17,23 +17,44 @@ export default (config = {}) => {
     return [];
   };
 
+  const _stringifyParams = params => Object.keys(params)
+    .reduce((acc, k) => `${acc}${k}=${encodeURIComponent(params[k])}&`, '')
+    .replace(/&$/, '');
+  //   const queryString = [];
+
+  //   Object.keys(params).forEach(k => {
+  //     queryString.push(`${k}=${encodeURIComponent(params[k])}`);
+  //   });
+
+  //   return queryString.join('&');
+  // };
+
   /**
    * This replaces any interpolated params with items passed in via the routeParams object
    *
    * @param {string} url
    * @param {Object} urlParams
+   * @param {Object} queryParams
    * @return {string}
    */
-  const _replaceURLParams = (url, urlParams) => {
+  const _replaceURLParams = (url, urlParams, queryParams) => {
     const routeParams = _getUrlParams(url);
     let mappedUrl = url;
 
-    // only do this if we have route params && params to replace
-    if (routeParams.length && Object.keys(urlParams).length !== 0) {
-      // replace each occurrence of the param with the value passed in
-      routeParams.forEach(param => {
-        mappedUrl = mappedUrl.replace(`{${param}}`, urlParams[param]);
-      });
+    if (Object.keys(urlParams).length !== 0) {
+      // only do this if we have route params
+      if (routeParams.length) {
+        // replace each occurrence of the param with the value passed in
+        routeParams.forEach(param => {
+          mappedUrl = mappedUrl.replace(`{${param}}`, urlParams[param]);
+        });
+      } else {
+        mappedUrl = `${mappedUrl}?${_stringifyParams(urlParams)}`;
+      }
+    }
+
+    if (Object.keys(queryParams).length !== 0) {
+      mappedUrl = `${mappedUrl}?${_stringifyParams(queryParams)}`;
     }
 
     return mappedUrl;
@@ -46,9 +67,10 @@ export default (config = {}) => {
    *
    * @param {string} k
    * @param {Object} params
+   * @param {Object} queryParams
    * @return {string}
    */
-  const generate = (k, params = {}) => _replaceURLParams(_get(k), params);
+  const generate = (k, params = {}, queryParams = {}) => _replaceURLParams(_get(k), params, queryParams);
 
   /**
    * Set a new route with a key and value
@@ -113,5 +135,6 @@ export default (config = {}) => {
     _get,
     _getUrlParams,
     _replaceURLParams,
+    _stringifyParams,
   };
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,6 +98,7 @@ describe('routeGen', () => {
     routes.set('foo', '/api/foo/bar');
     routes.set('foo_bar', '/bar/{id}');
     routes.set('foo_bar_baz', '/bar/{id}/{name}/foo');
+    routes.set('foo_to_append', '/api/foo/append');
 
     it('should generate a route with no params', () => {
       const expected = '/api/foo/bar';
@@ -115,6 +116,30 @@ describe('routeGen', () => {
       const expected = '/bar/134/drew/foo';
 
       expect(routes.generate('foo_bar_baz', { id: 134, name: 'drew' })).toEqual(expected);
+    });
+
+    it('should append query string params to the url if there are no params set', () => {
+      const expected = '/api/foo/append?id=1';
+
+      expect(routes.generate('foo_to_append', { id: 1 })).toEqual(expected);
+    });
+
+    it('should append query params when interpolated params are passed before them', () => {
+      const expected = '/bar/1?name=drew';
+
+      expect(routes.generate('foo_bar', { id: 1 }, { name: 'drew' })).toEqual(expected);
+    });
+  });
+
+  describe('_stringifyParams', () => {
+    const routes = routeGen();
+
+    routes.set('foo_to_append', '/api/foo/append');
+
+    it('should stringify multiple params', () => {
+      const expected = '/api/foo/append?id=1&bar=baz';
+
+      expect(routes.generate('foo_to_append', { id: 1, bar: 'baz' })).toEqual(expected);
     });
   });
 
@@ -136,13 +161,13 @@ describe('routeGen', () => {
     it('should replace the url params from a url and an object', () => {
       const routes = routeGen();
 
-      expect(routes._replaceURLParams('/foo/{id}', { id: 1 })).toEqual('/foo/1');
+      expect(routes._replaceURLParams('/foo/{id}', { id: 1 }, {})).toEqual('/foo/1');
     });
 
     it('should replace the url params from a url and an object', () => {
       const routes = routeGen();
 
-      expect(routes._replaceURLParams('/foo/{id}/{foo}', { id: 1, foo: 'bar' })).toEqual('/foo/1/bar');
+      expect(routes._replaceURLParams('/foo/{id}/{foo}', { id: 1, foo: 'bar' }, {})).toEqual('/foo/1/bar');
     });
   });
 


### PR DESCRIPTION
This PR adds support for query string parameters to be passed. They can be passed as follows:

```js
router.set('foo', '/foo');
router.generate('foo', { id: 1 }); // => /foo?id=1
```

If a route has params defined, you can pass the query string as a third parameter:

```js
router.set('foo', '/foo/{id}');
router.generate('foo', { id: 1 }, { bar: 'baz' }); // => /foo/1?bar=baz
```
